### PR TITLE
Maybe meetups should just be events?

### DIFF
--- a/app/views/layouts/navigation/_desktop_nav.html.haml
+++ b/app/views/layouts/navigation/_desktop_nav.html.haml
@@ -24,7 +24,7 @@
       %a.m-navbar__item{class: ('m-navbar__item--is-selected' if current_page?('/meetups')), href: events_path}
         %h2
           %i.fa.fa-group{"aria-hidden" => "true"}
-          Meetups
+          Events
 
     - if current_user
       = render partial: 'layouts/navigation/user_nav', locals: {logged_in: true}

--- a/app/views/layouts/navigation/_mobile_nav.html.haml
+++ b/app/views/layouts/navigation/_mobile_nav.html.haml
@@ -28,7 +28,7 @@
             %li
               %a{href: events_path}
                 %i.fa.fa-group{"aria-hidden" => "true"}
-                Meetups
+                Events
 
     .m-navbar--mobile-right
       - if current_user


### PR DESCRIPTION
Small cosmetic change. Might make sense if we do non-meetup events like
hackathons. Would also encourage people to use the "right" route?

-edit-

Would also make sense to change the language about "past meetups" etc.
to "past events". Can add that before merge if this is a thing you want to do